### PR TITLE
Fix restore dns servers list when app is gracefully shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.tool-versions
 /warp
 /.devcontainer
+vendor/
+.idea/

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/nsf/termbox-go v1.1.1 // indirect
 	golang.org/x/mod v0.12.0 // indirect
-	golang.org/x/net v0.15.0 // indirect
+	golang.org/x/net v0.15.0
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.13.0 // indirect

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -322,7 +322,7 @@ func (t *Service) ListenAndServe(ctx context.Context, protocols []Protocol) erro
 
 	handler.finish()
 
-	if err := sys.RestoreDNS(); err != nil {
+	if err := sys.RestoreDNS(t.addr); err != nil {
 		log.Error().Err(err).Msg("DNS", "restore dns")
 	}
 

--- a/internal/utils/sys/resolv.go
+++ b/internal/utils/sys/resolv.go
@@ -120,11 +120,13 @@ func getCurrentDNSServers(serviceName string) ([]string, error) {
 }
 
 func (r *resolvHandler) SetDNS(dns []string) error {
+	var servers string
 	if len(dns) == 0 {
-		return fmt.Errorf("%w: empty DNS server list", errInvalidDNS)
+		servers = "Empty"
+	} else {
+		servers = strings.Join(dns, " ")
 	}
 
-	servers := strings.Join(dns, " ")
 	if _, err := Command("networksetup -setdnsservers %s %s", r.service.Name, servers); err != nil {
 		return fmt.Errorf("%w: %w", errNetworkSetup, err)
 	}
@@ -148,8 +150,14 @@ func (r *resolvHandler) GetOriginalDNS() []string {
 	return r.backupDNS.Servers
 }
 
-func (r *resolvHandler) RestoreDNS() error {
-	return r.SetDNS(r.backupDNS.Servers)
+func (r *resolvHandler) RestoreDNS(currentAddr string) error {
+	var result []string
+	for _, elem := range r.backupDNS.Servers {
+		if elem != currentAddr {
+			result = append(result, elem)
+		}
+	}
+	return r.SetDNS(result)
 }
 
 func SetDNS(dns []string) error {
@@ -160,6 +168,6 @@ func GetOriginalDNS() []string {
 	return resolv.GetOriginalDNS()
 }
 
-func RestoreDNS() error {
-	return resolv.RestoreDNS()
+func RestoreDNS(currentAddr string) error {
+	return resolv.RestoreDNS(currentAddr)
 }


### PR DESCRIPTION
Если ДНС сервера не были сконфигурированы, то список отчищается корректно. Также если в списке днс для рестора по какой то причине остался dns для warp, то его тоже необходимо удалить. 